### PR TITLE
Fix color picker for newer Gradio versions

### DIFF
--- a/javascript/vec_cc.js
+++ b/javascript/vec_cc.js
@@ -60,7 +60,10 @@ onUiLoaded(async () => {
         container.style.width = 'auto'
 
         container.querySelector('.float').remove()
-        container.querySelector('.download').remove()
+        container.querySelector('.download')?.remove()
+        for (const downloadButton of container.querySelectorAll('[download]')) {
+            downloadButton.parentElement.remove()
+        }
 
         const wheel = container.getElementsByTagName('img')[0]
         wheel.style.height = '100%'


### PR DESCRIPTION
Gradio DOM looks to have changed in 3.39.0 (the version used on the `dev` branch and upcoming 1.6.0 version of the webui), so this resolves that. Should still work fine on older versions.