### PR TITLE
Fix config load/save

### DIFF
--- a/scripts/cc_version.py
+++ b/scripts/cc_version.py
@@ -5,12 +5,12 @@ import json
 VERSION = 'v1.5.0'
 
 def clean_outdated(EXT_NAME:str):
-    with open(scripts.basedir() + '/' + 'ui-config.json', 'r') as json_file:
+    with open(scripts.basedir() + '/' + 'ui-config.json', 'r', encoding='utf8') as json_file:
         configs = json.loads(json_file.read())
 
     cleaned_configs = {key: value for key, value in configs.items() if EXT_NAME not in key}
 
-    with open(scripts.basedir() + '/' + 'ui-config.json', 'w') as json_file:
+    with open(scripts.basedir() + '/' + 'ui-config.json', 'w', encoding='utf8') as json_file:
         json.dump(cleaned_configs, json_file)
 
 def refresh_sliders():


### PR DESCRIPTION
Fixes issue where the incorrect encoding is assumed, causing errors like this:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 390645: character maps to <undefined>
```